### PR TITLE
Switch from ref.key() to ref.key for SDK 3 compatibility

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -16,6 +16,7 @@ function MockFirebase (path, data, parent, name) {
   this.errs = {};
   this.priority = null;
   this.myName = parent ? name : extractName(path);
+  this.key = this.myName;
   this.flushDelay = parent ? parent.flushDelay : false;
   this.queue = parent ? parent.queue : new Queue();
   this._events = {
@@ -27,7 +28,7 @@ function MockFirebase (path, data, parent, name) {
   };
   this.parentRef = parent || null;
   this.children = {};
-  if (parent) parent.children[this.key()] = this;
+  if (parent) parent.children[this.key] = this;
   this.sortedDataKeys = [];
   this.data = null;
   this._dataChanged(_.cloneDeep(data) || null);
@@ -144,7 +145,7 @@ MockFirebase.prototype.child = function (childPath) {
   var child = this.children[childKey];
   if (!child) {
     child = new MockFirebase(utils.mergePaths(this.path, childKey), this._childData(childKey), this, childKey);
-    this.children[child.key()] = child;
+    this.children[child.key] = child;
   }
   if (parts.length) {
     child = child.child(parts.join('/'));
@@ -189,14 +190,10 @@ MockFirebase.prototype.setWithPriority = function (data, pri, callback) {
   this.set(data, callback);
 };
 
-MockFirebase.prototype.key = function () {
-  return this.myName;
-};
-
 /* istanbul ignore next */
 MockFirebase.prototype.name = function () {
-  console.warn('ref.name() is deprecated. Use ref.key()');
-  return this.key.apply(this, arguments);
+  console.warn('ref.name() is deprecated. Use ref.key');
+  return this.key;
 };
 
 MockFirebase.prototype.parent = function () {
@@ -332,7 +329,7 @@ MockFirebase.prototype.endAt = function (priority, key) {
 
 MockFirebase.prototype._childChanged = function (ref) {
   var events = [];
-  var childKey = ref.key();
+  var childKey = ref.key;
   var data = ref.getData();
   if( data === null ) {
     this._removeChild(childKey, events);
@@ -394,7 +391,7 @@ MockFirebase.prototype._priChanged = function (newPriority) {
   }
   this.priority = newPriority;
   if( this.parentRef ) {
-    this.parentRef._resort(this.key());
+    this.parentRef._resort(this.key);
   }
 };
 

--- a/src/query.js
+++ b/src/query.js
@@ -63,8 +63,8 @@ MockQuery.prototype.on = function (event, callback, cancelCallback, context) {
         }
         break;
       case 'child_moved':
-        var x = slice.pos(snap.key());
-        var y = slice.insertPos(snap.key());
+        var x = slice.pos(snap.key);
+        var y = slice.insertPos(snap.key);
         if (x > -1 && y > -1) {
           callback.call(context, snap, prevChild);
         }
@@ -73,7 +73,7 @@ MockQuery.prototype.on = function (event, callback, cancelCallback, context) {
         }
         break;
       case 'child_added':
-        if (slice.has(snap.key()) && lastSlice.has(snap.key())) {
+        if (slice.has(snap.key) && lastSlice.has(snap.key)) {
           // is a child_added for existing event so allow it
           callback.call(context, snap, prevChild);
         }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 
 function MockDataSnapshot (ref, data, priority) {
   this.ref = ref;
+  this.key = ref.key;
   data = _.cloneDeep(data);
   if (_.isObject(data) && _.isEmpty(data)) {
     data = null;
@@ -41,13 +42,9 @@ MockDataSnapshot.prototype.hasChildren = function () {
   return !!this.numChildren();
 };
 
-MockDataSnapshot.prototype.key = function () {
-  return this.ref.key();
-};
-
 MockDataSnapshot.prototype.name = function () {
-  console.warn('DataSnapshot.name() is deprecated. Use DataSnapshot.key()');
-  return this.key.apply(this, arguments);
+  console.warn('DataSnapshot.name() is deprecated. Use DataSnapshot.key');
+  return this.key;
 };
 
 MockDataSnapshot.prototype.numChildren = function () {

--- a/test/unit/firebase.js
+++ b/test/unit/firebase.js
@@ -367,7 +367,7 @@ describe('MockFirebase', function () {
       for (var i = 0; i < 3; i++) {
         var snapshot = spy.getCall(i).args[0];
         expect(snapshot.getPriority())
-          .to.equal(data[snapshot.key()]['.priority']);
+          .to.equal(data[snapshot.key]['.priority']);
       }
     });
 
@@ -500,7 +500,7 @@ describe('MockFirebase', function () {
       ref.child('a').remove();
       ref.flush();
       expect(spy.called).to.equal(true);
-      expect(spy.firstCall.args[0].key()).to.equal('a');
+      expect(spy.firstCall.args[0].key).to.equal('a');
     });
 
     it('changes to null if all children are removed', function () {

--- a/test/unit/query.js
+++ b/test/unit/query.js
@@ -179,7 +179,7 @@ describe('MockQuery', function () {
         query.flush();
         expect(spy).callCount(4);
         _.each(_.keys(data), function(k, i) {
-          expect(spy.getCall(i).args[0].key()).equals(k);
+          expect(spy.getCall(i).args[0].key).equals(k);
         });
       });
 
@@ -200,19 +200,19 @@ describe('MockQuery', function () {
         var last_key = null;
         ref.child('fruit').once('value', function(list_snapshot) {
           list_snapshot.forEach(function(snapshot){
-            model[snapshot.key()] = snapshot.val();
+            model[snapshot.key] = snapshot.val();
             snapshot.ref.on('value', function(snapshot) {
-              model[snapshot.key()] = snapshot.val();
+              model[snapshot.key] = snapshot.val();
             });
-            last_key = snapshot.key();
+            last_key = snapshot.key;
           });
 
           ref.child('fruit').startAt(null, last_key).on('child_added', function(snapshot) {
-            if(model[snapshot.key()] === undefined)
+            if(model[snapshot.key] === undefined)
             {
-              model[snapshot.key()] = snapshot.val();
+              model[snapshot.key] = snapshot.val();
               snapshot.ref.on('value', function(snapshot) {
-                model[snapshot.key()] = snapshot.val();
+                model[snapshot.key] = snapshot.val();
               });
             }
           }, undefined, this);
@@ -220,7 +220,7 @@ describe('MockQuery', function () {
 
         var third_ref = ref.child('fruit').push(third_value);
 
-        expect(model[third_ref.key()]).to.equal(third_value);
+        expect(model[third_ref.key]).to.equal(third_value);
 
       });
     });

--- a/test/unit/snapshot.js
+++ b/test/unit/snapshot.js
@@ -138,7 +138,9 @@ describe('DataSnapshot', function () {
   describe('#key', function () {
 
     it('returns the ref key', function () {
-      expect(new Snapshot(ref).key()).to.equal(ref.key());
+      var parent = new Snapshot(ref);
+      var child = parent.child('aChild');
+      expect(new Snapshot(child).key).to.equal(child.key);
     });
 
   });
@@ -147,7 +149,7 @@ describe('DataSnapshot', function () {
 
     it('passes through to #key', function () {
       var snapshot = new Snapshot(ref);
-      expect(snapshot.key()).to.equal(snapshot.name());
+      expect(snapshot.key).to.equal(snapshot.name());
     });
 
   });


### PR DESCRIPTION
Hi, The Firebase migration docs say ref.key() should be changed to ref.key. Here's my initial attempt to change to the property based API for key.