### PR TITLE
Move browserify and browserify-shim to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   "homepage": "https://github.com/soumak77/firebase-mock",
   "dependencies": {
     "MD5": "~1.2.1",
-    "browserify": "^6.3.2",
-    "browserify-shim": "^3.8.0",
     "firebase-auto-ids": "~1.1.0",
     "lodash": "~2.4.1",
     "rsvp": "^3.3.3"
   },
   "devDependencies": {
+    "browserify": "^6.3.2",
+    "browserify-shim": "^3.8.0",
     "chai": "~1.9.1",
     "es5-shim": "~4.0.1",
     "gulp": "^3.8.10",


### PR DESCRIPTION
Fixes issue #17.

It's not clear why these were moved to `devDependencies`: https://github.com/katowulf/mockfirebase/commit/7cf8515a8fcaa4f4134aa2c583ea2381a29befc2.

The only dependency on `browserify` is in [gulpfile.js](https://github.com/soumak77/firebase-mock/blob/202edfbd444f83475717845277868d1abae860bc/gulpfile.js#L6).  See: https://github.com/soumak77/firebase-mock/search?q=browserify.