### PR TITLE
Rename deprecated MD5 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "homepage": "https://github.com/soumak77/firebase-mock",
   "dependencies": {
-    "MD5": "~1.2.1",
+    "md5": "~2.2.1",
     "firebase-auto-ids": "~1.1.0",
     "lodash": "~2.4.1",
     "rsvp": "^3.3.3"

--- a/src/login.js
+++ b/src/login.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _   = require('lodash');
-var md5 = require('MD5');
+var md5 = require('md5');
 
 /*******************************************************************************
  * SIMPLE LOGIN


### PR DESCRIPTION
It is complaining when installing: `warning firebase-mock > MD5@1.2.2: deprecated, use lowercase 'md5@2.x' from now on`