### PR TITLE
Added support for EmailAuthProvider

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -6,6 +6,9 @@ function MockFirebaseSdk(createDatabase, createAuth) {
     delete auth.ref;
     return auth;
   }
+  MockFirebaseAuth.EmailAuthProvider = function() {
+    this.providerId = "password";
+  };
   MockFirebaseAuth.GoogleAuthProvider = function() {
     this.providerId = "google.com";
   };

--- a/test/unit/sdk.js
+++ b/test/unit/sdk.js
@@ -86,6 +86,15 @@ describe('MockFirebaseSdk', function () {
         .to.not.have.property('ref');
     });
 
+    describe('#EmailAuthProvider', function() {
+      it('sets provider id', function () {
+        var auth = new firebase.auth.EmailAuthProvider();
+        expect(auth)
+          .to.have.property('providerId')
+          .that.equals('password');
+      });
+    });
+
     describe('#GoogleAuthProvider', function() {
       it('sets provider id', function () {
         var auth = new firebase.auth.GoogleAuthProvider();


### PR DESCRIPTION
Hello,

I needed the EmailAuthProvider for my own testing purposes, and noticed that you don't have it. 
https://firebase.google.com/docs/reference/js/firebase.auth.EmailAuthProvider

So I took the liberty to create a PR containing it, hope it's fine. 

I did not mock the static PROVIDER_ID property, nor the credential method(they would both be within scope), because you only seem to mock the providerId for all the other Providers.

Not sure if there is any docs I should update, I did not find any relevant one. 

Thanks and keep up the good work!



