### PR TITLE
add firestore.QuerySnapshot docs property

### DIFF
--- a/src/firestore-query-snapshot.js
+++ b/src/firestore-query-snapshot.js
@@ -10,6 +10,10 @@ function MockFirestoreQuerySnapshot (data) {
   }
   this.size = _.size(this.data);
   this.empty = this.size === 0;
+
+  this.docs = _.map(this.data, function (value, key) {
+    new DocumentSnapshot(key, value);
+  });
 }
 
 MockFirestoreQuerySnapshot.prototype.forEach = function (callback, context) {

--- a/test/unit/firestore-query-snapshot.js
+++ b/test/unit/firestore-query-snapshot.js
@@ -58,4 +58,19 @@ describe('QuerySnapshot', function () {
       expect(new Snapshot(null).size).to.equal(0);
     });
   });
+
+  describe('#docs', function () {
+    it('returns the data as an array of snapshots', function () {
+      var snapshot = new Snapshot([{
+        foo: 'bar',
+        bar: 'baz'
+      },{
+        foo: 'bar2',
+        bar: 'baz2'
+      }]);
+      var docs = snapshot.docs;
+      expect(docs.length).to.equal(2);
+      expect(snapshot.size).to.equal(2);
+    });
+  });
 });


### PR DESCRIPTION
Added the missing `docs` property to `QuerySnapshot`.  The `docs` property is described here:  https://firebase.google.com/docs/reference/js/firebase.firestore.QuerySnapshot 