### PR TITLE
Allow set with merge option. #43

### DIFF
--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -86,7 +86,11 @@ MockFirestoreDocument.prototype.get = function () {
   });
 };
 
-MockFirestoreDocument.prototype.set = function (data, callback) {
+MockFirestoreDocument.prototype.set = function (data, opts, callback) {
+  var _opts = _.assign({}, { merge: false }, opts);
+  if (_opts.merge) {
+    return this._update(data, { setMerge: true }, callback);
+  }
   var err = this._nextErr('set');
   data = _.cloneDeep(data);
   var self = this;
@@ -105,15 +109,22 @@ MockFirestoreDocument.prototype.set = function (data, callback) {
   });
 };
 
-MockFirestoreDocument.prototype.update = function (changes, callback) {
+MockFirestoreDocument.prototype._update = function (changes, opts, callback) {
   assert.equal(typeof changes, 'object', 'First argument must be an object when calling "update"');
+  var _opts = _.assign({}, { setMerge: false }, opts);
   var err = this._nextErr('update');
   var self = this;
   return new Promise(function (resolve, reject) {
     self._defer('update', _.toArray(arguments), function () {
       if (!err) {
         var base = self.getData();
-        var data = _.merge(_.isObject(base) ? base : {}, utils.updateToObject(changes));
+        var data;
+        if (_opts.setMerge) {
+          data = _.merge(_.isObject(base) ? base : {}, changes);
+        }
+        else {
+          data = _.assign(_.isObject(base) ? base : {}, utils.updateToObject(changes));
+        }
         data = utils.removeEmptyProperties(data);
         self._dataChanged(data);
         resolve(data);
@@ -125,6 +136,10 @@ MockFirestoreDocument.prototype.update = function (changes, callback) {
       }
     });
   });
+};
+
+MockFirestoreDocument.prototype.update = function (changes, callback) {
+  return this._update(changes, { merge: false }, callback);
 };
 
 MockFirestoreDocument.prototype.delete = function (callback) {

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -139,7 +139,7 @@ MockFirestoreDocument.prototype._update = function (changes, opts, callback) {
 };
 
 MockFirestoreDocument.prototype.update = function (changes, callback) {
-  return this._update(changes, { merge: false }, callback);
+  return this._update(changes, { setMerge: false }, callback);
 };
 
 MockFirestoreDocument.prototype.delete = function (callback) {

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -83,8 +83,14 @@ MockFirestore.prototype.runTransaction = function(transFunc) {
 MockFirestore.prototype.batch = function () {
   var self = this;
   return {
-    set: function(doc, data) {
-      doc.set(data);
+    set: function(doc, data, opts) {
+      var _opts = _.assign({}, { merge: false }, opts);
+      if (_opts.merge) {
+        doc._update(data, { setMerge: true });
+      }
+      else {
+        doc.set(data);
+      }
     },
     update: function(doc, data) {
       doc.update(data);

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -98,6 +98,49 @@ describe('MockFirestoreDocument', function () {
     });
   });
 
+  describe('#set with {merge: true}', function () {
+    it('updates value of doc', function (done) {
+      doc.set({
+        title: 'title2',
+        nested: {
+          prop1: 'prop1'
+        }
+      });
+      doc.set({
+        nested: {
+          prop2: 'prop2'
+        }
+      }, { merge: true });
+
+      doc.get().then(function (snap) {
+        expect(snap.get('title')).to.equal('title2');
+        expect(snap.get('nested')).to.deep.equal({ prop1: 'prop1', prop2: 'prop2' });
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
+  });
+
+  describe('#update', function () {
+    it('updates value of doc', function (done) {
+      doc.set({
+        title: 'title2'
+      });
+      doc.update({
+        nextTitle: 'nextTitle'
+      });
+
+      doc.get().then(function (snap) {
+        expect(snap.get('title')).to.equal('title2');
+        expect(snap.get('nextTitle')).to.equal('nextTitle');
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
+  });
+
   describe('#delete', function () {
     it('delete doc', function () {
       var result;

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -139,6 +139,25 @@ describe('MockFirestoreDocument', function () {
 
       db.flush();
     });
+    it('does not merge nested properties recursively', function (done) {
+      doc.set({
+        nested: {
+          prop1: 'prop1'
+        }
+      });
+      doc.update({
+        nested: {
+          prop2: 'prop2'
+        }
+      });
+
+      doc.get().then(function (snap) {
+        expect(snap.get('nested')).to.deep.equal({ prop2: 'prop2' });
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
   });
 
   describe('#delete', function () {


### PR DESCRIPTION
MockFirestoreDocument.set accepts an options object as a second argument. Using set with {merge: true} updates existing data by recursively merging the changes. MockFirestoreDocument.update does not merge changes recursively.