### PR TITLE
Allow firestore mock to update fields with Date objects.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,7 @@ exports.removeEmptyProperties = function removeEmptyProperties(obj) {
   if (t === 'boolean' || t === 'string' || t === 'number' || t === 'undefined') {
     return obj;
   }
+  if (obj instanceof Date) return obj;
 
   var keys = getKeys(obj);
   if (keys.length === 0) {

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -120,6 +120,23 @@ describe('MockFirestoreDocument', function () {
 
       db.flush();
     });
+    it('can update date fields', function (done) {
+      var date = new Date(2018, 2, 2);
+      var nextDate = new Date(2018, 3, 3);
+      doc.set({
+        date: date
+      });
+      doc.set({
+        date: nextDate
+      }, { merge: true });
+
+      doc.get().then(function (snap) {
+        expect(snap.get('date').getTime()).to.equal(nextDate.getTime());
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
   });
 
   describe('#update', function () {
@@ -155,6 +172,25 @@ describe('MockFirestoreDocument', function () {
         expect(snap.get('nested')).to.deep.equal({ prop2: 'prop2' });
         done();
       }).catch(done);
+
+      db.flush();
+    });
+    it('can update date fields', function (done) {
+      var date = new Date(2018, 2, 2);
+      var nextDate = new Date(2018, 3, 3);
+      doc.set({
+        date: date
+      });
+      doc.update({
+        date: nextDate
+      });
+
+      doc.get()
+        .then(function (snap) {
+          expect(snap.get('date').getTime()).to.equal(nextDate.getTime());
+          done();
+        })
+        .catch(done);
 
       db.flush();
     });


### PR DESCRIPTION
Firestore supports Date fields. While using a Date when creating an object using set is possible, removeEmptyProperties currently strips Date fields from changes when updating an object and thus causes the fields to be deleted from the object.