### PR TITLE
allow specifying additional user attributes

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -279,11 +279,8 @@ FirebaseAuth.prototype._createUser = function (method, credentials, onComplete) 
       err = err || self._validateNewUid(credentials);
       if (!err) {
         var key = credentials.email;
-        users[key] = {
-          uid: credentials.uid || self._nextUid(),
-          email: key,
-          password: credentials.password
-        };
+        users[key] = _.cloneDeep(credentials);
+        users[key].uid = users[key].uid || self._nextUid();
         user = {
           uid: users[key].uid,
           email: key

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -354,6 +354,21 @@ describe('Auth', function () {
       expect(spy.firstCall.args[1].uid).to.equal('uid1');
     });
 
+    it('creates a new user with preset additional attributes', function () {
+      ref.createUser({
+        uid: 'uid1',
+        email: 'new1@new1.com',
+        password: 'new1',
+        displayName: 'new user 1',
+        emailVerified: true,
+      }, spy);
+      ref.flush();
+      return Promise.all([
+        expect(ref.getUser('uid1')).to.eventually.have.property('displayName', 'new user 1'),
+        expect(ref.getUser('uid1')).to.eventually.have.property('emailVerified', true),
+      ]);
+    });
+
     it('fails if credentials is not an object', function () {
       expect(ref.createUser.bind(ref, 29)).to.throw('must be a valid object');
     });


### PR DESCRIPTION
Currently, `createUser` only allows specifying uid, email and password.
As the real `firebase.User` interface has many more properties (ie.
`displayName`, `disabled`, ...), some tests are not easy to configure in
firebase-mock.

To help here, copy all properties of credentials over to the newly created user object.
A whitelist of allowed properties could be added as well as validation
rules on types and values, but this would increase maintenance as it
would need to be kept up-to-date.

Docs:
https://firebase.google.com/docs/reference/js/firebase.User