### PR TITLE
add equalTo to instances of MockFirebase

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -419,6 +419,14 @@ MockFirebase.prototype.endAt = function (priority, key) {
   return new Query(this).endAt(priority, key);
 };
 
+/**
+ * Just a stub so it can be spied on during testing
+ */
+MockFirebase.prototype.equalTo = function () {
+  console.warn("equalTo() is not supported by firebase-mock.  You will need to use spies to test this functionality.  Please refer to the firebase-mock README for more info.");
+  return new Query(this);
+};
+
 MockFirebase.prototype._childChanged = function (ref) {
   var events = [];
   var childKey = ref.key;


### PR DESCRIPTION
A firebase reference exposes an `equalTo` method, which currently is
only exposed on `firebase-mock`'s `Query` instances but not on instances of `MockFirebase`.

Therefore adding `equalTo` as follows:
- `equalTo` is a stub that returns a Query to the whole dataset
- `equalTo` is only there to ease spying/mocking
- add a warning message to make users aware of this being a no-op and
needs to be mocked

Docs:
https://firebase.google.com/docs/reference/js/firebase.database.Reference#equalTo