### PR TITLE
Expose firestore property on Query, CollectionReference and DocumentReference

### DIFF
--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -18,6 +18,7 @@ function MockFirestoreDocument(path, data, parent, name, CollectionReference) {
   this.flushDelay = parent ? parent.flushDelay : false;
   this.queue = parent ? parent.queue : new Queue();
   this.parent = parent || null;
+  this.firestore = parent ? parent.firestore : null;
   this.children = {};
   if (parent) parent.children[this.id] = this;
   this.data = null;

--- a/src/firestore-query.js
+++ b/src/firestore-query.js
@@ -16,6 +16,7 @@ function MockFirestoreQuery(path, data, parent, name) {
   this.flushDelay = parent ? parent.flushDelay : false;
   this.queue = parent ? parent.queue : new Queue();
   this.parent = parent || null;
+  this.firestore = parent ? parent.firestore : null;
   this.children = {};
   this.orderedProperties = [];
   this.orderedDirections = [];

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -14,6 +14,7 @@ var DEFAULT_PATH = 'Mock://';
 
 function MockFirestore(path, data, parent, name) {
   this.ref = this;
+  this.firestore = this;
   this.path = path || DEFAULT_PATH;
   this.errs = {};
   this.priority = null;

--- a/test/unit/firestore-collection.js
+++ b/test/unit/firestore-collection.js
@@ -128,6 +128,14 @@ describe('MockFirestoreCollection', function () {
       var doc = collection.doc();
       expect(doc.id).to.be.a('string');
     });
+
+    it('creates child documents with a firestore property pointing at the root db', function () {
+      expect(collection.doc('doc').firestore).to.equal(db);
+    });
+
+    it('creates child documents with a firestore property pointing at the firestore of the collection', function () {
+      expect(collection.doc('doc').firestore).to.equal(collection.firestore);
+    });
   });
 
   describe('#add', function () {

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -65,6 +65,14 @@ describe('MockFirestoreDocument', function () {
         doc.collection('collection');
       }).to.not.throw();
     });
+
+    it('creates child collections with a firestore property pointing at the root db', function () {
+      expect(doc.collection('doc').firestore).to.equal(db);
+    });
+
+    it('creates child collections with a firestore property pointing at the firestore of the collection', function () {
+      expect(doc.collection('doc').firestore).to.equal(doc.firestore);
+    });
   });
 
   describe('#get', function () {

--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -75,6 +75,10 @@ describe('MockFirestore', function () {
     it('caches deep children with paths', function () {
       expect(db.collection('collections/doc/collections2')).to.equal(db.collection('collections').doc('doc').collection('collections2'));
     });
+
+    it('creates child collection with a firestore property pointing at itself', function () {
+      expect(db.collection('collections').firestore).to.equal(db);
+    });
   });
 
   describe('#doc', function () {
@@ -100,6 +104,10 @@ describe('MockFirestore', function () {
 
     it('caches deep children with paths', function () {
       expect(db.doc('doc/collections/doc2')).to.equal(db.doc('doc').collection('collections').doc('doc2'));
+    });
+
+    it('creates child document with a firestore property pointing at itself', function () {
+      expect(db.doc('doc').firestore).to.equal(db);
     });
   });
 


### PR DESCRIPTION
Per the specification of https://firebase.google.com/docs/reference/js/firebase.firestore.Query and https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentReference, add a firestore property onto these references.

To minimize disruption of code and to best match the other parent relationships, pull the property from the parent if available.

I saw no tests for other similar properties like queue so did not add one but can if that is desired.