### PR TITLE
remove empty properties after running transactions

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -345,6 +345,7 @@ MockFirebase.prototype.transaction = function (valueFn, finishedFn, applyLocally
   var self = this;
   return new Promise(function (resolve, reject) {
     self._defer('transaction', _.toArray(arguments), function () {
+      newData = utils.removeEmptyRtdbProperties(newData);
       self._dataChanged(newData);
       if (typeof finishedFn === 'function') {
         finishedFn(err, err === null && !_.isUndefined(res), new Snapshot(self, newData, self.priority));

--- a/test/unit/firebase.js
+++ b/test/unit/firebase.js
@@ -847,7 +847,26 @@ describe('MockFirebase', function () {
 
       expect(ref.getData().item).to.eql(ref.child('item').getData());
     });
+
+    it('should remove empty properties from data', function(){
+      ref.transaction(function(value) {
+        return {
+          alpha: true,
+          bravo: [],
+          charlie: "some string",
+          delta: {nestedArray:[]},
+          echo: 5
+        };
+      });
+      ref.flush();
+
+      expect(ref.getData()).to.eql({
+          alpha: true,
+          charlie: "some string",
+          echo: 5
+      });
   });
+});
 
   describe('#push', function () {
 


### PR DESCRIPTION
`set` and `update` are already doing this, adding the same for `transaction`

NOTE: This breaks any existing tests which expect `null` values