### PR TITLE
Support ref.push() without arguments

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -240,7 +240,7 @@ MockFirebase.prototype.push = function (data, callback) {
     validate.data(data);
     return utils.createThenableReference(child, child.set(data, callback));
   } else {
-    return utils.createThenableReference(child, Promise.resolve(null));
+    return utils.createThenableReference(child, Promise.resolve(child));
   }
 };
 

--- a/test/unit/firebase.js
+++ b/test/unit/firebase.js
@@ -886,6 +886,14 @@ describe('MockFirebase', function () {
       }, done);
       ref.flush();
     });
+    
+    it('should return thenable reference when no arguments are passed', function (done) {
+      var thenable = ref.push();
+      thenable.then(function(child) {
+        expect(child.parent).to.eql(ref);
+        done();
+      }, done);
+    });
 
     it('can add data by auto id', function () {
       var id = ref._newAutoId();


### PR DESCRIPTION
The example in the firebase docs shows this use: https://firebase.google.com/docs/reference/js/firebase.database.Reference#push

Calling .push() should create a child and return a reference to it. You're already creating the child, but currently you're returning null, so it looks like a pretty small change to support this behaviour.