### PR TITLE
Support firestore.doc.create

### DIFF
--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -88,7 +88,7 @@ MockFirestoreDocument.prototype.get = function () {
 };
 
 MockFirestoreDocument.prototype._validateDoesNotExist = function (data) {
-  if (data) {
+  if (data !== null) {
     var err = new Error('Cannot create a document which already exists');
     err.code = 'firestore/already-exists';
     return err;

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -88,9 +88,11 @@ MockFirestoreDocument.prototype.get = function () {
 };
 
 MockFirestoreDocument.prototype._validateDoesNotExist = function (data) {
+  var ALREADY_EXISTS_CODE = 6;
+
   if (data !== null) {
     var err = new Error('Cannot create a document which already exists');
-    err.code = 'firestore/already-exists';
+    err.code = ALREADY_EXISTS_CODE;
     return err;
   }
   return null;

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -87,6 +87,38 @@ MockFirestoreDocument.prototype.get = function () {
   });
 };
 
+MockFirestoreDocument.prototype._validateDoesNotExist = function (data) {
+  if (data) {
+    var err = new Error('Cannot create a document which already exists');
+    err.code = 'firestore/already-exists';
+    return err;
+  }
+  return null;
+};
+
+MockFirestoreDocument.prototype.create = function (data, callback) {
+  var err = this._nextErr('create');
+  data = _.cloneDeep(data);
+
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    self._defer('create', _.toArray(arguments), function () {
+
+      var base = self._getData();
+      err = err || self._validateDoesNotExist(base);
+        if (err === null) {
+        self._dataChanged(data);
+        resolve();
+      } else {
+          if (callback) {
+            callback(err);
+        }
+          reject(err);
+      }
+    });
+  });
+};
+
 MockFirestoreDocument.prototype.set = function (data, opts, callback) {
   var _opts = _.assign({}, { merge: false }, opts);
   if (_opts.merge) {

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -81,6 +81,9 @@ MockFirestore.prototype.batch = function () {
         doc.set(data);
       }
     },
+    create: function(doc, data) {
+      doc.create(data);
+    },
     update: function(doc, data) {
       doc.update(data);
     },

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -131,7 +131,7 @@ describe('MockFirestoreDocument', function () {
           done('should have thrown an error');
         })
         .catch(function(error) {
-          expect(error.code).to.equal('firestore/already-exists');
+          expect(error.code).to.equal(6);
           done();
         });
 

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -92,6 +92,53 @@ describe('MockFirestoreDocument', function () {
     });
   });
 
+  describe('#create', function () {
+    it('creates a new doc', function (done) {
+      var createDoc = db.doc('createDoc');
+
+      createDoc.create({prop: 'title'});
+
+      createDoc.get().then(function (snap) {
+        expect(snap.exists).to.equal(true);
+        expect(snap.get('prop')).to.equal('title');
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
+
+    it('creates a new doc with null values', function (done) {
+      var createDoc = db.doc('createDoc');
+
+      createDoc.create({prop: null});
+
+      createDoc.get().then(function (snap) {
+        expect(snap.exists).to.equal(true);
+        expect(snap.get('prop')).to.equal(null);
+        done();
+      }).catch(done);
+
+      db.flush();
+    });
+
+    it('throws an error when a doc already exists', function (done) {
+      var createDoc = db.doc('createDoc');
+      createDoc.create({prop: 'data'});
+      db.flush();
+
+      createDoc.create({otherProp: 'more data'})
+        .then(function() {
+          done('should have thrown an error');
+        })
+        .catch(function(error) {
+          expect(error.code).to.equal('firestore/already-exists');
+          done();
+        });
+
+      db.flush();
+    });
+  });
+
   describe('#set', function () {
     it('sets value of doc', function (done) {
       doc.set({

--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -148,6 +148,9 @@ describe('MockFirestore', function () {
         expect(db.collection('collections').doc('a').get()).to.eventually.have.property('exists').equal(true)
       ]).then(function() {
         var batch = db.batch();
+        batch.create(db.doc('docToCreate'), {
+          name: 'abc'
+        });
         batch.update(db.doc('doc'), {
           name: 'abc'
         });
@@ -157,6 +160,7 @@ describe('MockFirestore', function () {
         batch.delete(db.collection('collections').doc('a'));
         batch.commit().then(function() {
           Promise.all([
+            expect(db.doc('docToCreate').get()).to.eventually.have.property('exists').equal(true),
             expect(db.doc('doc2').get()).to.eventually.have.property('exists').equal(true),
             expect(db.collection('collections').doc('a').get()).to.eventually.have.property('exists').equal(false)
           ]).then(function() {

--- a/tutorials/client/firestore.md
+++ b/tutorials/client/firestore.md
@@ -3,7 +3,7 @@
 When writing unit tests with Firebase Mock, you'll typically want to focus on covering one of two scenarios:
 
 1. Your client receives data from Firestore using a method like `get`
-2. Your client writes data to Firestore using a method like `set` or `update`
+2. Your client writes data to Firestore using a method like `set`, `create` or `update`
 
 While your application almost certainly does both reading and writing to Firestore, each test should try to cover as small a unit of functionality as possible.
 


### PR DESCRIPTION
Hiya, I've made an attempt at #77 . 

The approach has been to largely mimic behaviour for set, but to throw an error if the document exists. 
I'm working off the idea that the document exists if the data is not null.

Let me know any feedback. 

Cheers!