### PR TITLE
Enable chaining of firestore batch methods.

### DIFF
--- a/src/firestore.js
+++ b/src/firestore.js
@@ -71,7 +71,7 @@ MockFirestore.prototype.runTransaction = function(transFunc) {
 
 MockFirestore.prototype.batch = function () {
   var self = this;
-  return {
+  var batch = {
     set: function(doc, data, opts) {
       var _opts = _.assign({}, { merge: false }, opts);
       if (_opts.merge) {
@@ -80,12 +80,15 @@ MockFirestore.prototype.batch = function () {
       else {
         doc.set(data);
       }
+      return batch;
     },
     update: function(doc, data) {
       doc.update(data);
+      return batch;
     },
     delete: function(doc) {
       doc.delete();
+      return batch;
     },
     commit: function() {
       if (self.queue.events.length > 0) {
@@ -94,6 +97,7 @@ MockFirestore.prototype.batch = function () {
       return Promise.resolve();
     }
   };
+  return batch;
 };
 
 MockFirestore.prototype.collection = function (path) {

--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -185,5 +185,35 @@ describe('MockFirestore', function () {
 
       db.flush();
     });
+
+    it('supports method chaining', function () {
+      var doc1 = db.doc('doc1');
+      var doc2 = db.doc('doc2');
+      var doc3 = db.doc('doc3');
+      var doc4 = db.doc('doc4');
+
+      doc3.set({value: -1});
+      doc4.set({value: 4});
+
+      db.batch()
+        .set(doc1, {value: 1})
+        .set(doc2, {value: 2})
+        .update(doc3, {value: 3})
+        .delete(doc4)
+        .commit();
+
+      var awaitChecks = Promise
+        .all([doc1.get(), doc2.get(), doc3.get(), doc4.get()])
+        .then(function(snaps) {
+          expect(snaps[0].data()).to.deep.equal({value: 1});
+          expect(snaps[1].data()).to.deep.equal({value: 2});
+          expect(snaps[2].data()).to.deep.equal({value: 3});
+          expect(snaps[3].exists).to.equal(false);
+        });
+
+      db.flush();
+
+      return awaitChecks;
+    });
   });
 });


### PR DESCRIPTION
This updates the object returned by `firestore.batch()` to allow chaining on the `set`, `update`, and `delete` methods.

See return type of each method in https://firebase.google.com/docs/reference/js/firebase.firestore.WriteBatch#delete