### PR TITLE
Flush batch only after "commit" is called

### DIFF
--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -185,5 +185,33 @@ describe('MockFirestore', function () {
 
       db.flush();
     });
+
+    context('when "batch.commit" is not called', function () {
+      afterEach(function () {
+        db.doc('col/batch-foo').delete();
+        db.doc('col/batch-bar').delete();
+        db.flush();
+      });
+
+      it('does not create documents', function (done) {
+        var batch = db.batch();
+        batch.set(db.doc('col/batch-foo'), { foo: 'fooo' });
+        batch.set(db.doc('col/batch-bar'), { bar: 'barr' });
+
+        expect(function () { db.flush() }).to.throw(Error)
+
+        var promises = [
+          db.doc('col/batch-foo').get(),
+          db.doc('col/batch-bar').get()
+        ]
+        db.flush()
+
+        Promise.all(promises).then(function (docs) {
+          expect(docs[0].exists).to.eq(false);
+          expect(docs[1].exists).to.eq(false);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Store batch operations in a queue before execution. This will prevent
documents from being created/updated/deleted before `batch.commit()` is
even called. This issue was especially annoying when autoFlush is enabled.