### PR TITLE
Fix for #102

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -16,7 +16,10 @@ function MockDataSnapshot (ref, data, priority) {
 
 MockDataSnapshot.prototype.child = function (key) {
   var ref = this.ref.child(key);
-  var data = this.hasChild(key) ? this._snapshotdata[key] : null;
+  var data = null;
+  if (_.isObject(this._snapshotdata) && !_.isUndefined(this._snapshotdata[key])) {
+    data = this._snapshotdata[key];
+  }
   var priority = this.ref.child(key).priority;
   return new MockDataSnapshot(ref, data, priority);
 };

--- a/test/unit/snapshot.js
+++ b/test/unit/snapshot.js
@@ -63,6 +63,18 @@ describe('DataSnapshot', function () {
       expect(child.val()).to.equal('val');
     });
 
+    it('uses child data for false values', function () {
+      var parent = new Snapshot(ref, {key: false});
+      var child = parent.child('key');
+      expect(child.val()).to.equal(false);
+    });
+
+    it('uses child data for 0 values', function () {
+      var parent = new Snapshot(ref, {key: 0});
+      var child = parent.child('key');
+      expect(child.val()).to.equal(0);
+    });
+
     it('uses null when there is no child data', function () {
       var parent = new Snapshot(ref);
       var child = parent.child('key');


### PR DESCRIPTION
Fixes #102 - all values except for `undefined` are used as data.

Included tests.