### PR TITLE
Fixed accessing DataSnapshot with multiple paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - "4.5"
 - "5.12"
 - "6.4"
+- "8"
 before_script:
 - gulp lint
 script:

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,4 @@ exports.MockFirestore = require('./firestore');
 exports.MockStorage = require('./storage');
 exports.MockMessaging = require('./messaging');
 exports.DeltaDocumentSnapshot = MockFirestoreDeltaDocumentSnapshot.create;
+exports.DataSnapshot = require('./snapshot');

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -15,6 +15,7 @@ function MockDataSnapshot (ref, data, priority) {
 }
 
 MockDataSnapshot.prototype.child = function (path) {
+  if (typeof path === 'number') path = String(path);
   // Strip leading or trailing /
   path = path.replace(/^\/|\/$/g, '');
   var ref = this.ref.child(path);

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -14,14 +14,33 @@ function MockDataSnapshot (ref, data, priority) {
   };
 }
 
-MockDataSnapshot.prototype.child = function (key) {
-  var ref = this.ref.child(key);
+MockDataSnapshot.prototype.child = function (path) {
+  // Strip leading or trailing /
+  path = path.replace(/^\/|\/$/g, '');
+  var ref = this.ref.child(path);
   var data = null;
+  
+  var key;
+  var firstPathIdx = path.indexOf('/');
+  if (firstPathIdx === -1) {
+    // Single path
+    key = path;
+    path = null;
+  } else {
+    // Multiple paths
+    key = path.slice(0, firstPathIdx);
+    path = path.slice(firstPathIdx + 1);
+  }
   if (_.isObject(this._snapshotdata) && !_.isUndefined(this._snapshotdata[key])) {
     data = this._snapshotdata[key];
   }
-  var priority = this.ref.child(key).priority;
-  return new MockDataSnapshot(ref, data, priority);
+  var snapshot = new MockDataSnapshot(ref, data, ref.priority);
+  if (path === null) {
+    return snapshot;
+  } else {
+    // Look for child
+    return snapshot.child(path);
+  }
 };
 
 MockDataSnapshot.prototype.val = function () {
@@ -40,7 +59,7 @@ MockDataSnapshot.prototype.forEach = function (callback, context) {
 };
 
 MockDataSnapshot.prototype.hasChild = function (path) {
-  return !!(this._snapshotdata && this._snapshotdata[path]);
+  return this.child(path).exists();
 };
 
 MockDataSnapshot.prototype.hasChildren = function () {

--- a/test/unit/snapshot.js
+++ b/test/unit/snapshot.js
@@ -63,6 +63,18 @@ describe('DataSnapshot', function () {
       expect(child.val()).to.equal('val');
     });
 
+    it('uses child data starting with /', function () {
+      var parent = new Snapshot(ref, {key: 'val'});
+      var child = parent.child('/key');
+      expect(child.val()).to.equal('val');
+    });
+
+    it('uses child data ending with /', function () {
+      var parent = new Snapshot(ref, {key: 'val'});
+      var child = parent.child('key/');
+      expect(child.val()).to.equal('val');
+    });
+
     it('uses child data for false values', function () {
       var parent = new Snapshot(ref, {key: false});
       var child = parent.child('key');
@@ -72,6 +84,24 @@ describe('DataSnapshot', function () {
     it('uses child data for 0 values', function () {
       var parent = new Snapshot(ref, {key: 0});
       var child = parent.child('key');
+      expect(child.val()).to.equal(0);
+    });
+
+    it('uses child data when accessing with multiple paths', function () {
+      var parent = new Snapshot(ref, { key: { value: 'val' }});
+      var child = parent.child('key/value');
+      expect(child.val()).to.equal('val');
+    });
+
+    it('uses child data when accessing with multiple paths for false values', function () {
+      var parent = new Snapshot(ref, { key: { value: false }});
+      var child = parent.child('key/value');
+      expect(child.val()).to.equal(false);
+    });
+
+    it('uses child data when accessing with multiple paths for 0 values', function () {
+      var parent = new Snapshot(ref, { key: { value: 0 }});
+      var child = parent.child('key/value');
       expect(child.val()).to.equal(0);
     });
 
@@ -135,6 +165,24 @@ describe('DataSnapshot', function () {
       var snapshot = new Snapshot(ref, {foo: 'bar'});
       expect(snapshot.hasChild('foo')).to.equal(true);
       expect(snapshot.hasChild('bar')).to.equal(false);
+    });
+
+    it('tests for the key starting with /', function () {
+      var snapshot = new Snapshot(ref, {foo: 'bar'});
+      expect(snapshot.hasChild('/foo')).to.equal(true);
+      expect(snapshot.hasChild('/bar')).to.equal(false);
+    });
+
+    it('tests for the key ending with /', function () {
+      var snapshot = new Snapshot(ref, {foo: 'bar'});
+      expect(snapshot.hasChild('foo/')).to.equal(true);
+      expect(snapshot.hasChild('bar/')).to.equal(false);
+    });
+
+    it('tests for the key with multiple paths', function () {
+      var snapshot = new Snapshot(ref, {key: {foo: 'bar'}});
+      expect(snapshot.hasChild('key/foo')).to.equal(true);
+      expect(snapshot.hasChild('key/bar')).to.equal(false);
     });
 
   });

--- a/test/unit/snapshot.js
+++ b/test/unit/snapshot.js
@@ -119,6 +119,18 @@ describe('DataSnapshot', function () {
       expect(child.getPriority()).to.equal(10);
     });
 
+    it('allows array indexes', function () {
+      var parent = new Snapshot(ref, ['foo', 'bar']);
+      var child = parent.child(0);
+      expect(child.val()).to.equal('foo');
+    });
+
+    it('allows array indexes in multiple paths', function () {
+      var parent = new Snapshot(ref, { key: { array: ['foo', 'bar'] }});
+      var child = parent.child('key/array/1');
+      expect(child.val()).to.equal('bar');
+    });
+
   });
 
   describe('#exists', function () {


### PR DESCRIPTION
With this following data snapshot:

```
{
     foo: {
          bar: 'val'
     }
}
```

Calling `snapshot.child('foo/bar').val()` should be `val` - but as `.child` (and also `.hasChild`) just checks `this._snapshotdata` for the `key` without splitting it by `/` it returns `null`. Includes tests.

Also it would be useful to have this available so code that interacts with DataSnapshots directly (it might merge various snapshots into a single object, etc.) can be tested, so I've exported snapshot.js as `DataSnapshot`.

Finally I've also added node 8 to the travis test matrix - hope this is ok!