### PR TITLE
Changes stream to implement the Readable interface

### DIFF
--- a/src/firestore-query.js
+++ b/src/firestore-query.js
@@ -110,13 +110,19 @@ MockFirestoreQuery.prototype.get = function () {
 };
 
 MockFirestoreQuery.prototype.stream = function () {
-  var stream = new Stream();
+  var stream = new Stream.Transform({
+    objectMode: true,
+    transform: function (chunk, encoding, done) {
+      this.push(chunk);
+      done();
+    }
+  });
 
   this.get().then(function (snapshots) {
     snapshots.forEach(function (snapshot) {
-      stream.emit('data', snapshot);
+      stream.write(snapshot);
     });
-    stream.emit('end');
+    stream.end();
   });
 
   return stream;


### PR DESCRIPTION
`MockFirestoreQuery.prototype.stream` was using the underlying `EventEmitter` to emit the events which bypassed the stream's logic.

This PR changes it to return a Transformable stream.

That will make stream reader functions available like `stream.pause()`, `stream.resume()` or `stream.read()`.

The existing tests pass.