### PR TITLE
Add listDocuments to collection

### DIFF
--- a/src/firestore-collection.js
+++ b/src/firestore-collection.js
@@ -65,6 +65,23 @@ MockFirestoreCollection.prototype.doc = function (path) {
   return child;
 };
 
+MockFirestoreCollection.prototype.listDocuments = function () {
+  var err = this._nextErr('listDocuments');
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    self._defer('listDocuments', _.toArray(arguments), function () {
+      if (err === null) {
+        var docs = _.map(self.data, function (value, key) {
+          return self.doc(key);
+        });
+        resolve(docs);
+      } else {
+        reject(err);
+      }
+    });
+  });
+};
+
 MockFirestoreCollection.prototype._hasChild = function (key) {
   return _.isObject(this.data) && _.has(this.data, key);
 };

--- a/test/unit/firestore-collection.js
+++ b/test/unit/firestore-collection.js
@@ -356,4 +356,31 @@ describe('MockFirestoreCollection', function () {
       ]);
     });
   });
+  describe('#listDocuments', function () {
+    it('retrieves all data for existing collection', function(done) {
+      db.autoFlush();
+      var keys = Object.keys(require('./data.json').collections);
+      collection.listDocuments().then(function(refs) {
+        expect(refs.length).to.equal(6);
+        refs.forEach(function(ref) {
+          expect(keys).to.contain(ref.id);
+        });
+        done();
+      }).catch(done);
+    });
+
+    it('retrieves data added to collection', function(done) {
+      db.autoFlush();
+      db.collection('group').add({
+        name: 'test'
+      });
+      db.collection('group').listDocuments().then(function(refs) {
+        expect(refs.length).to.equal(1);
+        refs[0].get().then(function(doc) {
+          expect(doc.data().name).to.equal('test');
+          done();
+        }).catch(done);
+      }).catch(done);
+    });
+  });
 });


### PR DESCRIPTION
This adds support for the `listDocuments` method to `CollectionReference`.

I need this when calling firestore from a service and not from a client. When preparing this PR I realised that this method only exists in the `firebase-admin` package and not in the `firebase` package. How have you dealt with differences like this before?

References:
1. https://cloud.google.com/nodejs/docs/reference/firestore/latest/CollectionReference#listDocuments
2. https://firebase.google.com/docs/reference/js/firebase.firestore.CollectionReference
3. https://github.com/googleapis/nodejs-firestore/pull/368