### PR TITLE
Ignore ReadOptions on getAll

### DIFF
--- a/src/firestore.js
+++ b/src/firestore.js
@@ -59,6 +59,9 @@ MockFirestore.prototype.toString = function () {
 
 MockFirestore.prototype.getAll = function(/* ...docs */) {
   var docs = Array.from(arguments);
+  if (_.isEmpty(docs)) {
+    throw new Error('Firestore.getAll: Function requires at least 1 argument.');
+  }
   return Promise.all(
     docs.map(function(doc) {
       return doc.get();

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -62,6 +62,10 @@ MockFirestore.prototype.getAll = function(/* ...docs */) {
   if (_.isEmpty(docs)) {
     throw new Error('Firestore.getAll: Function requires at least 1 argument.');
   }
+  // ReadOptions is not honored but at least ignored
+  if (!_.isUndefined(docs[docs.length - 1].fieldMask)) {
+    docs.pop();
+  }
   return Promise.all(
     docs.map(function(doc) {
       return doc.get();

--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -262,6 +262,9 @@ describe('MockFirestore', function () {
   });
 
   describe('#getAll', function() {
+    it('requires one argument', function() {
+      expect(db.getAll).to.throw('Function requires at least 1 argument');
+    });
     it('gets the value of all passed documents', function() {
       var doc1 = db.doc('doc1');
       var doc2 = db.doc('doc2');

--- a/test/unit/firestore.js
+++ b/test/unit/firestore.js
@@ -284,5 +284,22 @@ describe('MockFirestore', function () {
         expect(snaps[2].exists).to.equal(false);
       });
     });
+    it('gets the value of all passed documents honoring the read options', function() {
+      var doc1 = db.doc('doc1');
+      var doc2 = db.doc('doc2');
+
+      doc1.set({value: 1});
+      doc2.set({value: 2});
+
+      var getAll = db
+        .getAll(doc1, doc2, { fieldMask: ['value'] });
+
+      db.flush();
+
+      return getAll.then(function(snaps) {
+        expect(snaps[0].data()).to.deep.equal({value: 1});
+        expect(snaps[1].data()).to.deep.equal({value: 2});
+      });
+    });
   });
 });


### PR DESCRIPTION
This change ignores the optional `ReadOptions` in `firestore.getAll`. It also raises an exception if no argument were passed at all.

If you use the `firebase-admin` package and call `getAll` with only one argument; `ReadOptions` -- it will actually do the round-trip to the backend. If you have no arguments at all, it raises an exception and no promise is created. This behaviour is also mimicked.

> The first argument is required and must be of type DocumentReference followed by any additional DocumentReference documents. If used, the optional ReadOptions must be the last argument.

References:
https://cloud.google.com/nodejs/docs/reference/firestore/latest/Firestore#getAll