### PR TITLE
Resolve create() with WriteResult

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -44,17 +44,12 @@ MockFirebase.ServerValue = {
   }
 };
 
-var getServerTime, defaultClock;
-getServerTime = defaultClock = function () {
-  return new Date().getTime();
-};
-
 MockFirebase.setClock = function (fn) {
-  getServerTime = fn;
+  utils.setServerClock(fn);
 };
 
 MockFirebase.restoreClock = function () {
-  getServerTime = defaultClock;
+  utils.restoreServerClock();
 };
 
 MockFirebase.autoId = function () {
@@ -449,7 +444,7 @@ MockFirebase.prototype._dataChanged = function (unparsedData) {
   var data = utils.cleanData(unparsedData);
 
   if (utils.isServerTimestamp(data)) {
-    data = getServerTime();
+    data = utils.getServerTime();
   }
 
   if (pri !== this.priority) {
@@ -475,7 +470,7 @@ MockFirebase.prototype._dataChanged = function (unparsedData) {
       keysToChange.forEach(function (key) {
         var childData = unparsedData[key];
         if (utils.isServerTimestamp(childData)) {
-          childData = getServerTime();
+          childData = utils.getServerTime();
         }
         self._updateOrAdd(key, childData, events);
       });
@@ -493,7 +488,7 @@ MockFirebase.prototype._dataChanged = function (unparsedData) {
 
 MockFirebase.prototype._priChanged = function (newPriority) {
   if (utils.isServerTimestamp(newPriority)) {
-    newPriority = getServerTime();
+    newPriority = utils.getServerTime();
   }
   this.priority = newPriority;
   if (this.parent) {

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -6,8 +6,10 @@ var Promise = require('rsvp').Promise;
 var autoId = require('firebase-auto-ids');
 var DocumentSnapshot = require('./firestore-document-snapshot');
 var Queue = require('./queue').Queue;
+var Timestamp = require('./timestamp');
 var utils = require('./utils');
 var validate = require('./validators');
+var WriteResult = require('./write-result');
 
 function MockFirestoreDocument(path, data, parent, name, CollectionReference) {
   this.ref = this;
@@ -108,9 +110,11 @@ MockFirestoreDocument.prototype.create = function (data, callback) {
 
       var base = self._getData();
       err = err || self._validateDoesNotExist(base);
-        if (err === null) {
+      if (err === null) {
+        var time = Timestamp.fromDate(new Date());
+        var result = new WriteResult(time);
         self._dataChanged(data);
-        resolve();
+        resolve(result);
       } else {
           if (callback) {
             callback(err);

--- a/src/firestore-document.js
+++ b/src/firestore-document.js
@@ -111,7 +111,7 @@ MockFirestoreDocument.prototype.create = function (data, callback) {
       var base = self._getData();
       err = err || self._validateDoesNotExist(base);
       if (err === null) {
-        var time = Timestamp.fromDate(new Date());
+        var time = Timestamp.fromMillis(utils.getServerTime());
         var result = new WriteResult(time);
         self._dataChanged(data);
         resolve(result);

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function Timestamp(seconds, nanoseconds) {
+  this.seconds = seconds;
+  this.nanoseconds = nanoseconds;
+}
+
+Timestamp.fromDate = function(date) {
+  var sec = Math.floor(date.getTime() / 1000);
+  var ns = (date.getTime() % 1000) * 1000 * 1000;
+  return new Timestamp(sec, ns);
+};
+
+Timestamp.prototype.toDate = function () {
+  var millis = this.seconds * 1000 + this.nanoseconds / (1000 * 1000);
+  return new Date(millis);
+};
+
+module.exports = Timestamp;

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -6,8 +6,12 @@ function Timestamp(seconds, nanoseconds) {
 }
 
 Timestamp.fromDate = function(date) {
-  var sec = Math.floor(date.getTime() / 1000);
-  var ns = (date.getTime() % 1000) * 1000 * 1000;
+  return Timestamp.fromMillis(date.getTime());
+};
+
+Timestamp.fromMillis = function(ms) {
+  var sec = Math.floor(ms / 1000);
+  var ns = (ms % 1000) * 1000 * 1000;
   return new Timestamp(sec, ns);
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,6 +75,24 @@ exports.priorityComparator = function priorityComparator(a, b) {
   return 0;
 };
 
+var serverClock, defaultClock;
+
+serverClock = defaultClock = function () {
+  return new Date().getTime();
+};
+
+exports.getServerTime = function getServerTime() {
+  return serverClock();
+};
+
+exports.setServerClock = function setServerTime(fn) {
+  serverClock = fn;
+};
+
+exports.restoreServerClock = function restoreServerTime() {
+  serverClock = defaultClock;
+};
+
 exports.isServerTimestamp = function isServerTimestamp(data) {
   return _.isObject(data) && data['.sv'] === 'timestamp';
 };

--- a/src/write-result.js
+++ b/src/write-result.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function WriteResult(writeTime) {
+  this.writeTime = writeTime;
+}
+
+module.exports = WriteResult;

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -96,7 +96,9 @@ describe('MockFirestoreDocument', function () {
     it('creates a new doc', function (done) {
       var createDoc = db.doc('createDoc');
 
-      createDoc.create({prop: 'title'});
+      createDoc.create({prop: 'title'}).then(function (result) {
+        expect(result).to.have.property('writeTime');
+      }).catch(done);
 
       createDoc.get().then(function (snap) {
         expect(snap.exists).to.equal(true);

--- a/test/unit/firestore-document.js
+++ b/test/unit/firestore-document.js
@@ -10,6 +10,7 @@ chai.use(require('sinon-chai'));
 var expect = chai.expect;
 var _ = require('../../src/lodash');
 var Firestore = require('../../').MockFirestore;
+var Firebase = require('../../').MockFirebase;
 
 describe('MockFirestoreDocument', function () {
 
@@ -94,10 +95,14 @@ describe('MockFirestoreDocument', function () {
 
   describe('#create', function () {
     it('creates a new doc', function (done) {
+      Firebase.setClock(function() {
+        return 1234567890123;
+      });
       var createDoc = db.doc('createDoc');
 
       createDoc.create({prop: 'title'}).then(function (result) {
         expect(result).to.have.property('writeTime');
+        expect(result.writeTime.seconds).to.equal(1234567890);
       }).catch(done);
 
       createDoc.get().then(function (snap) {

--- a/test/unit/timestamp.js
+++ b/test/unit/timestamp.js
@@ -13,6 +13,13 @@ describe('Timestamp', function () {
       expect(timestamp.nanoseconds).to.equal(123000000);
     });
   });
+  describe('fromMillis', function () {
+    it('should convert from milliseconds', function () {
+      var timestamp = Timestamp.fromMillis(1234567890123);
+      expect(timestamp.seconds).to.equal(1234567890);
+      expect(timestamp.nanoseconds).to.equal(123000000);
+    });
+  });
   describe('#toDate', function () {
     it('should convert to date', function () {
       var ts = new Timestamp(1234567890, 123456789);

--- a/test/unit/timestamp.js
+++ b/test/unit/timestamp.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var expect   = require('chai').use(require('sinon-chai')).expect;
+var sinon    = require('sinon');
+var Timestamp = require('../../src/timestamp');
+
+describe('Timestamp', function () {
+  describe('fromDate', function () {
+    it('should convert from date', function () {
+      var date = new Date('2009-02-13T23:31:30.123456789Z');
+      var timestamp = Timestamp.fromDate(date);
+      expect(timestamp.seconds).to.equal(1234567890);
+      expect(timestamp.nanoseconds).to.equal(123000000);
+    });
+  });
+  describe('#toDate', function () {
+    it('should convert to date', function () {
+      var ts = new Timestamp(1234567890, 123456789);
+      var date = ts.toDate();
+      expect(date.toISOString()).to.equal('2009-02-13T23:31:30.123Z');
+    });
+  });
+});


### PR DESCRIPTION
This change makes the `create()` method on `DocumentReference` resolve with `WriteResult` as described in the document.

References:
https://cloud.google.com/nodejs/docs/reference/firestore/latest/DocumentReference#create